### PR TITLE
:sparkles: feat : search bar 공용 컴포넌트 구현

### DIFF
--- a/src/components/common/searchBar.tsx
+++ b/src/components/common/searchBar.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import searchIcon from "../../assets/icons/search.svg";
+import searchIcon from "@/assets/icons/search.svg";
 
 interface SearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
   width?: string;
@@ -44,7 +44,7 @@ function SearchBar({
         ref={inputRef}
         type="text"
         placeholder="검색어를 입력해주세요"
-        className={`flex-1 outline-none font-pretendard placeholder:text-sm placeholder:font-normal placeholder:leading-5 ${className}`}
+        className={`flex-1 outline-none font-pretendard placeholder:text-sm placeholder:text-gray-400 placeholder:font-normal placeholder:leading-5 ${className}`}
         onKeyDown={handleKeyDown}
         {...props}
       />


### PR DESCRIPTION
## 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 설명

- search-bar 공용 컴포넌트 제작했습니다.
- 기본값으로 width : 256px, height: 40px 넣어놨고, 그냥 `<searchBar />` 만 해도 컴포넌트는 나오지만, 엔터키는 작동되지 않습니다.
- 반응형을 구현 안해도 되서, width랑 height 받을까 고민했었는데 피그마에서 관심사목록 페이지에서의 크기와, 컴포넌트에서 나와있는 크기가 달라서 그냥 구현해놨습니다.

## 스크린샷 (UI 변경 시)

<img width="518" height="106" alt="image" src="https://github.com/user-attachments/assets/bd978467-c05a-4e76-8b44-ba91dd4a2f7a" />


## 체크리스트

- [x] 로컬에서 테스트 완료
- [x] 코드 스타일 확인
- [ ] 브라우저 호환성 확인 (필요시)
