### PR TITLE
✨ feat : 공용 컴포넌트 label 구현

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,19 @@
+interface LabelProp {
+  src?: string;
+  label: string;
+}
+
+export default function Label({ src, label }: LabelProp) {
+  return (
+    <div className="flex gap-1.5 items-center w-fit">
+      {src && (
+        <div className="p-0.5 bg-slate-200 rounded-full">
+          <img src={src} className="w-5 h-5 rounded-full" />
+        </div>
+      )}
+      <p className="font-pretendard font-semibold text-sm leading-5 text-slate-500">
+        {label}
+      </p>
+    </div>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- 공용 컴포넌트 label 구현했습니다.
- prop 으로 이미지 src와 label (이름) 만 받으면 끝이라서 간단합니다.
- 이미지가 없을시에는 label 만 보이도록 했습니다.

## 스크린샷 (UI 변경 시)

<img width="616" height="238" alt="image" src="https://github.com/user-attachments/assets/a8efb0ac-0b98-44a1-9904-65daa4e58b72" />

<img width="430" height="238" alt="image" src="https://github.com/user-attachments/assets/44a7b2d8-50f0-49c0-8c88-4a608c106eb1" />


## 체크리스트

- [x] 로컬에서 테스트 완료
- [x] 코드 스타일 확인
