### PR TITLE
:sparkles: feat : 공통 훅 useClosePopup 추가

### DIFF
--- a/src/shared/hooks/useClosePopup.ts
+++ b/src/shared/hooks/useClosePopup.ts
@@ -1,0 +1,35 @@
+// '창 바깥 클릭, esc 키다운 시 닫힘' 기능 수행
+import { useEffect } from "react";
+
+export const useClosePopup = (
+  ref: React.RefObject<HTMLElement | null>,
+  onClose: () => void
+) => {
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+
+      if (
+        ref.current &&
+        target instanceof Node &&
+        !ref.current.contains(target)
+      ) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose, ref]);
+};

--- a/src/shared/hooks/useClosePopup.ts
+++ b/src/shared/hooks/useClosePopup.ts
@@ -3,9 +3,12 @@ import { useEffect } from "react";
 
 export const useClosePopup = (
   ref: React.RefObject<HTMLElement | null>,
-  onClose: () => void
+  onClose: () => void,
+  isOpen: boolean = true
 ) => {
   useEffect(() => {
+    if (!isOpen) return;
+
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as Node | null;
 
@@ -24,12 +27,12 @@ export const useClosePopup = (
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleClickOutside, true);
+    document.addEventListener("keydown", handleKeyDown, true);
 
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleClickOutside, true);
+      document.removeEventListener("keydown", handleKeyDown, true);
     };
-  }, [onClose, ref]);
+  }, [onClose, ref, isOpen]);
 };


### PR DESCRIPTION
## Description

<!--이 PR에서 무엇을 변경했는지 간단히 설명 -->
`useClosePopup.ts` 훅 추가: 요소 바깥 클릭, esc 키다운 시 요소 닫힘 기능을 수행

사용 예제 코드
```
const containerRef = useRef<HTMLDivElement>(null);
const [isOpen, setIsOpen] = useState(false);

useClosePopup(
  containerRef,
  () => setIsOpen(false),
  isOpen
);
```

## 체크리스트

- [x] 로컬에서 테스트 완료
- [x] 코드 스타일 확인
