### PR TITLE
:sparkles: feat : Toast 컴포넌트 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.12.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router": "^7.9.1"
+        "react-router": "^7.9.1",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -2341,6 +2342,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4244,6 +4254,19 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "axios": "^1.12.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router": "^7.9.1"
+    "react-router": "^7.9.1",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,19 @@
+import "react-toastify/dist/ReactToastify.css";
+import { Slide, ToastContainer } from "react-toastify";
+
+export default function Toast() {
+  return (
+    <ToastContainer
+      hideProgressBar={true}
+      closeButton={false}
+      limit={2}
+      position="top-center"
+      autoClose={3000}
+      newestOnTop={true}
+      transition={Slide}
+      draggable
+      pauseOnHover
+      pauseOnFocusLoss
+    />
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,12 @@
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import App from "./App";
+import Toast from "./components/common/Toast";
 import "./styles/globals.css";
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>
+    <Toast />
     <App />
   </BrowserRouter>
 );

--- a/src/pages/feed/ArticlesPage.tsx
+++ b/src/pages/feed/ArticlesPage.tsx
@@ -1,9 +1,0 @@
-function ArticlesPage() {
-  return (
-    <div>
-      <h1>Articles</h1>
-    </div>
-  );
-}
-
-export default ArticlesPage;

--- a/src/pages/test/TestPage.tsx
+++ b/src/pages/test/TestPage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router";
 import { ROUTES } from "@/shared/constants/routes";
 import { login } from "@/api/users";
 import Button from "@/components/common/button/Button";
+import { toast } from "react-toastify";
 
 const testEmail = {
   email: "mmgg@codeit.com",
@@ -16,11 +17,12 @@ export default function TestPage() {
       const user = await login(testEmail);
       sessionStorage.setItem("user", JSON.stringify(user));
       console.log("로그인 성공", user);
+      toast.success("환영합니다! 로그인이 완료되었습니다.");
 
       navigate(ROUTES.ARTICLES);
     } catch (error) {
       console.error("로그인 실패", error);
-      alert("로그인 실패");
+      toast.error("잠시 후 다시 시도해 주세요.");
     }
   };
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "./font.css";
 @import "./text.css";
 @import "./color.css";
+@import "./toast.css";
 
 @layer base {
   html,

--- a/src/styles/toast.css
+++ b/src/styles/toast.css
@@ -1,0 +1,22 @@
+@import "tailwindcss";
+
+.Toastify__toast {
+  width: fit-content !important;
+  max-width: 380px !important;
+  min-width: 200px;
+  white-space: normal !important;
+  text-align: center !important;
+  margin: 0 auto !important;
+  word-break: keep-all;
+  border-radius: 8px;
+  padding: 12px 24px !important;
+  background-color: rgba(0, 0, 0, 0.5) !important;
+  color: white;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+:root {
+  --toastify-icon-color-success: #47cd89;
+  --toastify-icon-color-error: #ff6257;
+}


### PR DESCRIPTION
## Description

<!--이 PR에서 무엇을 변경했는지 간단히 설명 -->
- 피그마 시안과 일치하는 토스트 설정
등장/퇴장 효과는 Slide로 설정했습니다 ~!
```
npm install react-toastify
```
📢 toastify 설치해 주세요

- 사용 방법
```
import { toast } from "react-toastify";
toast.success("환영합니다! 로그인이 완료되었습니다.");
toast.error("잠시 후 다시 시도해 주세요.");
```
TestPage에 작성해 두었습니다!

<br/>

## 스크린샷 (UI 변경 시)

<!-- 변경된 화면이 있다면 스크린샷 첨부 -->
<img width="371" height="88" alt="스크린샷 2025-09-24 160550" src="https://github.com/user-attachments/assets/0174953b-38f6-4695-a765-866664811b54" />

## 체크리스트

- [x] 로컬에서 테스트 완료
- [x] 코드 스타일 확인
