### PR TITLE
:sparkles: feat : comment, comment-history, interest card 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.12.2",
+        "date-fns": "^4.1.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router": "^7.9.1",
@@ -2444,6 +2445,16 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "axios": "^1.12.2",
+    "date-fns": "^4.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router": "^7.9.1",

--- a/src/assets/icons/person.svg
+++ b/src/assets/icons/person.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="9" r="3" fill="#D1D5DB"/>
+<path d="M7 17C7 14.7909 8.79086 13 11 13H13C15.2091 13 17 14.7909 17 17V18C17 18.5523 16.5523 19 16 19H8C7.44772 19 7 18.5523 7 18V17Z" fill="#D1D5DB"/>
+</svg>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -5,6 +5,7 @@ import { useId, useState } from "react";
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
   label?: string;
+  inputSize?: "sm" | "md";
 }
 
 export default function Input({
@@ -14,6 +15,7 @@ export default function Input({
   value,
   onChange,
   label,
+  inputSize = "md",
   className,
   ...props
 }: InputProps) {
@@ -34,8 +36,13 @@ export default function Input({
     return showPassword ? "text" : "password";
   };
 
+  const sizeClasses = {
+    sm: "min-h-10 py-1.5 px-3",
+    md: "min-h-14 py-4 px-5",
+  };
+
   return (
-    <div>
+    <div className={className}>
       {label && (
         <label
           htmlFor={inputId}
@@ -46,7 +53,7 @@ export default function Input({
       )}
 
       <div
-        className={`w-full min-h-14 border rounded-lg mt-1 py-4 px-5 gap-2.5 bg-white ${error ? "border-error" : "border-slate-200"} focus-within:border-blue-500 ${className || ""}`}
+        className={`w-full border rounded-lg mt-1 gap-2.5 bg-white ${sizeClasses[inputSize]} ${error ? "border-error" : "border-slate-200"} focus-within:border-blue-500 ${className || ""}`}
       >
         <div className="flex items-center justify-between">
           <input

--- a/src/components/card/Comment.tsx
+++ b/src/components/card/Comment.tsx
@@ -1,0 +1,124 @@
+import likeDefault from "@/assets/icons/like-default.svg";
+import likeActive from "@/assets/icons/like-active.svg";
+import { formatDistanceToNow } from "date-fns";
+import { ko } from "date-fns/locale";
+import type { CommentId } from "@/types/ids";
+import Input from "../Input";
+import Button from "../common/button/Button";
+import { useState } from "react";
+
+interface CommentProps {
+  userNickname: string;
+  createdAt: Date;
+  likeCount: number;
+  content: string;
+  isLiked: boolean;
+  commentId: CommentId;
+  isMyComment: boolean;
+  onLikeClick: (commentId: CommentId) => void;
+  onEditSave: (commentId: CommentId, newContent: string) => void;
+  className?: string;
+}
+
+export default function Comment({
+  userNickname,
+  createdAt,
+  likeCount,
+  content,
+  isLiked,
+  onLikeClick,
+  onEditSave,
+  commentId,
+  isMyComment,
+  className,
+}: CommentProps) {
+  const [commentValue, setCommentValue] = useState(content);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleHeartClick = () => {
+    onLikeClick(commentId);
+  };
+
+  const handleEditClick = () => {
+    setIsEditing(true);
+    setCommentValue(content);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setCommentValue(content);
+  };
+
+  const handleSaveEdit = () => {
+    if (commentValue.trim()) {
+      onEditSave(commentId, commentValue.trim());
+      setIsEditing(false);
+    }
+  };
+
+  return (
+    <div
+      className={`w-full h-auto border-slate-300 py-4 px-4 bg-slate-100 rounded-lg ${className || ""}`}
+    >
+      <div className="flex justify-between pr-1 gap-2 mb-2.5">
+        <div className="gap-1 flex items-center">
+          <span className="text-14-m text-slate-500">{userNickname}</span>
+          <span className="text-14-m text-slate-500 ">·</span>
+          <span className="text-14-m text-slate-500">
+            {formatDistanceToNow(createdAt, { addSuffix: true, locale: ko })}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* 본인 댓글이고 수정 모드가 아닐 때 수정 버튼 나오게 */}
+          {isMyComment && !isEditing && (
+            <button
+              onClick={handleEditClick}
+              className="text-14-r text-slate-400 hover:text-slate-600"
+            >
+              수정
+            </button>
+          )}
+
+          <button
+            onClick={handleHeartClick}
+            className="flex justify-center items-center gap-2"
+          >
+            {isLiked ? (
+              <img src={likeActive} className="w-6 h-6" alt="활성화 하트" />
+            ) : (
+              <img src={likeDefault} className="w-6 h-6" alt="비활성화 하트" />
+            )}
+            <p className="text-14-r text-slate-500">{likeCount}</p>
+          </button>
+        </div>
+      </div>
+
+      {isMyComment && isEditing ? (
+        <div className={`flex items-center gap-2.5 w-full`}>
+          <Input
+            inputSize="sm"
+            value={commentValue}
+            onChange={(e) => setCommentValue(e.target.value)}
+            className="flex-1"
+          />
+          <Button
+            variant="tertiary"
+            size="sm"
+            className="w-16 mt-1"
+            onClick={handleCancelEdit}
+          >
+            취소
+          </Button>
+          <Button size="sm" className="w-16 mt-1" onClick={handleSaveEdit}>
+            수정
+          </Button>
+        </div>
+      ) : (
+        <div>
+          <p className="text-16-r text-slate-700">{content}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/card/CommentHistory.tsx
+++ b/src/components/card/CommentHistory.tsx
@@ -1,0 +1,81 @@
+import { formatDistanceToNow } from "date-fns";
+import { ko } from "date-fns/locale";
+import subDirectoryIcon from "@/assets/icons/subdirectory.svg";
+import likeDefault from "@/assets/icons/like-default.svg";
+import likeActive from "@/assets/icons/like-active.svg";
+import type { ArticleId, CommentId } from "@/types/ids";
+
+interface CommentHistoryProps {
+  createdAt: Date;
+  likeCount: number;
+  content: string;
+  isLiked: boolean;
+  commentId: CommentId;
+  articleId: ArticleId;
+  title: string;
+  onLikeClick: (commentId: CommentId) => void;
+  onTitleClick: (articleId: ArticleId) => void;
+  className?: string;
+}
+
+export default function CommentHistory({
+  createdAt,
+  isLiked,
+  likeCount,
+  commentId,
+  articleId,
+  title,
+  content,
+  className,
+  onLikeClick,
+  onTitleClick,
+}: CommentHistoryProps) {
+  const handleHeartClick = () => {
+    onLikeClick(commentId);
+  };
+
+  const handleTitleClick = () => {
+    onTitleClick(articleId);
+  };
+  return (
+    <div
+      className={`w-full h-auto px-8 pb-10 pt-8 bg-white border border-slate-300 ${className || ""}`}
+    >
+      <div className="flex mb-5">
+        <div>
+          <button
+            className="text-16-r text-cyan-500 hover:text-cyan-600 hover:underline cursor-pointer"
+            onClick={handleTitleClick}
+          >
+            {title}
+          </button>
+          <span className="text-16-r">에 남긴 댓글</span>
+        </div>
+        <div className="flex gap-1 ml-1">
+          <span className="text-14-m text-slate-500 mt-0.5">·</span>
+          <span className="text-14-m text-slate-500 mt-0.5">
+            {formatDistanceToNow(createdAt, { addSuffix: true, locale: ko })}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <img src={subDirectoryIcon} className="w-6 h-6" alt="답글" />
+          <span className="text-18-sb line-clamp-1">{content}</span>
+        </div>
+        <button
+          onClick={handleHeartClick}
+          className="flex justify-center items-center gap-2"
+        >
+          {isLiked ? (
+            <img src={likeActive} className="w-6 h-6" alt="활성화 하트" />
+          ) : (
+            <img src={likeDefault} className="w-6 h-6" alt="비활성화 하트" />
+          )}
+          <p className="text-14-r text-slate-500">{likeCount}</p>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/card/Interest.tsx
+++ b/src/components/card/Interest.tsx
@@ -1,0 +1,160 @@
+import kebabMenuIcon from "@/assets/icons/kebab-menu-32.svg";
+import personIcon from "@/assets/icons/person.svg";
+import checkIcon from "@/assets/icons/check-default.svg";
+import Button from "../common/button/Button";
+import { useEffect, useRef, useState } from "react";
+import type { InterestId } from "@/types/ids";
+import Dropdown from "../dropdown";
+import { useClosePopup } from "@/shared/hooks/useClosePopup";
+
+interface InterestProps {
+  interestId: InterestId;
+  name: string;
+  keywords: string[];
+  subscriberCount: number;
+  isSubscribed?: boolean;
+  onSubscribeClick: (id: InterestId, isSubscribed: boolean) => void;
+  onEditKeyword: (id: InterestId) => void;
+  onSaveKeyword: (id: InterestId, keywordText: string) => void;
+  onCancelKeyword: () => void; //키워드 수정 취소
+  onDeleteInterest: (id: InterestId) => void;
+}
+
+export default function Interest({
+  interestId,
+  name,
+  keywords,
+  subscriberCount,
+  isSubscribed = false,
+  onSubscribeClick,
+  onEditKeyword,
+  onSaveKeyword,
+  onCancelKeyword,
+  onDeleteInterest,
+}: InterestProps) {
+  const [isSubscribe, setIsSubscribe] = useState(isSubscribed);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [keywordText, setKeywordText] = useState("");
+  const dropdownRef = useRef<HTMLButtonElement>(null);
+
+  useClosePopup(dropdownRef, () => setIsDropdownOpen(false), isDropdownOpen);
+
+  // 편집 시작시 현재 키워드들을 텍스트로 설정하기
+  useEffect(() => {
+    if (isEditing) {
+      setKeywordText(keywords.join(", "));
+    }
+  }, [isEditing, keywords]);
+
+  const handleSubScribeClick = () => {
+    setIsSubscribe(!isSubscribe);
+    onSubscribeClick(interestId, !isSubscribe);
+  };
+
+  const handleDropdownChange = (selectedItem: string) => {
+    if (selectedItem === "키워드 수정") {
+      setIsEditing(true);
+      onEditKeyword(interestId);
+    } else if (selectedItem === "관심사 삭제") {
+      onDeleteInterest(interestId);
+    }
+    setIsDropdownOpen(false); //메뉴선택시 드롭다운 닫히게
+  };
+
+  const handleKeywordSave = () => {
+    onSaveKeyword(interestId, keywordText);
+    setIsEditing(false);
+  };
+
+  const handleKeywordCancel = () => {
+    onCancelKeyword();
+    setIsEditing(false);
+    setKeywordText("");
+  };
+
+  return (
+    <div className="w-full h-auto border border-slate-200 rounded-2xl p-6 bg-white">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-20-b text-slate-900">{name}</h2>
+        <button
+          className="relative"
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+          ref={dropdownRef}
+        >
+          <img src={kebabMenuIcon} className="w-8 h-8" alt="케밥" />
+          {isDropdownOpen && (
+            <Dropdown
+              items={["키워드 수정", "관심사 삭제"]}
+              onChange={handleDropdownChange}
+              className="right-0 top-7 z-10 min-w-32"
+            />
+          )}
+        </button>
+      </div>
+      {isEditing ? (
+        <div className="mb-6">
+          <textarea
+            value={keywordText}
+            onChange={(e) => setKeywordText(e.target.value)}
+            className="w-full p-3 border border-slate-300 rounded-lg resize-none"
+            rows={3}
+            placeholder="키워드를 쉼표(,)로 구분해서 입력하세요"
+          />
+          <div className="flex gap-2 mt-2">
+            <button
+              onClick={handleKeywordSave}
+              className="px-4 py-2 bg-blue-500 text-white rounded"
+            >
+              저장
+            </button>
+            <button
+              onClick={handleKeywordCancel}
+              className="px-4 py-2 bg-gray-500 text-white rounded"
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2 mb-6">
+          {keywords.map((keyword, index) => (
+            <div
+              key={index}
+              className="rounded-lg py-1 px-2 bg-slate-100 text-16-m text-slate-500"
+            >
+              {keyword}
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex justify-between items-center">
+        <div className="flex items-center justify-center">
+          <img src={personIcon} className="w-6 h-6" alt="사람모양" />
+          <span className="text-14-r text-slate-500">
+            {subscriberCount} 구독자
+          </span>
+        </div>
+        {isSubscribe ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            className="flex gap-1 min-w-[91px]"
+            onClick={handleSubScribeClick}
+          >
+            <img src={checkIcon} className="w-4 h-4" alt="체크" />
+            구독 중
+          </Button>
+        ) : (
+          <Button
+            className="min-w-[80px]"
+            size="sm"
+            onClick={handleSubScribeClick}
+          >
+            구독하기
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -17,7 +17,7 @@ export default function Dropdown({
 
   return (
     <div
-      className={`box-border bg-white border border-gray-200 rounded-lg overflow-hidden ${className}`}
+      className={`absolute box-border bg-white border border-gray-200 rounded-lg overflow-hidden ${className}`}
     >
       <ul className={`py-1 max-h-60 overflow-y-auto cursor-pointer`}>
         {items.map((item, index) => (


### PR DESCRIPTION
## Description

- comment card, comment-history card, interest card 구현했습니다.
- date-fns 라이브러리 설치했습니다. `npm i` 해주세요. (~~ 몇분전, ~몇시간전 나타낼 때 쓰입니다 !)
- Input에서 쓰이는곳이 전부 height가 56px 인줄 알았는데, 40px 인곳도 있어가지구 inputSize prop 추가해줬습니다.
- comment card 에서 피그마상에서 수정버튼이 없어서 수정버튼 추가했습니다.
- Interest card 에서 케밥아이콘 누르면 뭐나오는지 피그마에 설명이 없더라구요. 그래서, 키워드 수정, 관심사 삭제 넣었습니다. 키워드 수정에 대한 모달이 없어서, 그냥 textarea `'키워드' , '키워드' , '키워드'` 이런식으로 나오게 해서, 지우면 수정되는 식으로 구현했습니다.
- 아래 이미지는 더미데이터 넣어서 테스트해본 결과입니다.

## 스크린샷 (UI 변경 시)

<img width="958" height="144" alt="스크린샷 2025-09-24 오후 7 43 12" src="https://github.com/user-attachments/assets/60731f28-f896-4784-b737-16027c9a91f3" />

<img width="958" height="144" alt="스크린샷 2025-09-24 오후 7 43 21" src="https://github.com/user-attachments/assets/fdfa469c-a064-448c-a18d-9ed8b23990fc" />

<img width="1095" height="213" alt="스크린샷 2025-09-24 오후 8 34 10" src="https://github.com/user-attachments/assets/e6e9caa4-fa9e-4418-8b25-263afbde7275" />

<img width="474" height="331" alt="스크린샷 2025-09-25 오전 12 28 54" src="https://github.com/user-attachments/assets/f84d10db-77c5-460d-902b-825191a2f2d4" />

<img width="474" height="331" alt="스크린샷 2025-09-25 오전 12 28 57" src="https://github.com/user-attachments/assets/14b7cef4-9274-44bc-b85a-22efc4164c4d" />

<img width="474" height="428" alt="스크린샷 2025-09-25 오전 12 29 11" src="https://github.com/user-attachments/assets/3388beb6-9027-43ba-b284-4af24bc401dd" />


## 체크리스트

- [x] 로컬에서 테스트 완료
- [x] 코드 스타일 확인
