### PR TITLE
✨ feat: article-page 구현

### DIFF
--- a/src/api/articles/types.ts
+++ b/src/api/articles/types.ts
@@ -46,7 +46,7 @@ export type GetArticlesParams = {
   cursor?: string;
   after?: string;
   limit: number;
-  requestUserId: UserId;
+  requestUserId?: UserId;
 };
 
 /* 뉴스 기사 목록 조회 - 응답 */

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -50,13 +50,13 @@ export default function Input({
       )}
 
       <div
-        className={`w-full border rounded-lg mt-1.5 gap-2.5 bg-white ${sizeClasses[inputSize]} ${error ? "border-error" : "border-slate-200"} focus-within:border-cyan-500 ${className || ""}`}
+        className={`w-full border rounded-lg mt-1.5 gap-2.5 ${props.disabled ? "bg-gray-50" : "bg-white"} ${sizeClasses[inputSize]} ${error ? "border-error" : "border-slate-200"} focus-within:border-cyan-500 ${className || ""}`}
       >
         <div className="flex items-center justify-between">
           <input
             type={getInputType()}
             placeholder={placeholder}
-            className="flex-1 outline-none bg-transparent text-16-m text-gray-900 pr-2"
+            className={`flex-1 outline-none bg-transparent text-16-m pr-2 ${props.disabled ? "text-gray-400 cursor-not-allowed" : "text-gray-900"}`}
             value={value}
             onChange={onChange}
             id={inputId}

--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -8,6 +8,9 @@ interface SelectBarProps {
   value?: string;
   onChange: (value: string) => void;
   className?: string;
+  noBorder?: boolean;
+  textClassName?: string;
+  noBackground?: boolean;
 }
 
 export default function SelectBox({
@@ -16,6 +19,9 @@ export default function SelectBox({
   value,
   onChange,
   className = "w-full h-10",
+  noBorder = false,
+  textClassName = "text-14-m",
+  noBackground = false,
 }: SelectBarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const selectRef = useRef<HTMLDivElement>(null);
@@ -49,18 +55,18 @@ export default function SelectBox({
     <div ref={selectRef} className={`relative ${className}`}>
       <button
         type="button"
-        className={`border rounded-lg border-slate-200 py-2.5 px-3 bg-white cursor-pointer w-full h-full focus:outline-none`}
+        className={`${noBorder ? "" : "border rounded-lg border-slate-200"} ${noBackground ? "" : "bg-white"} py-2.5 px-3 cursor-pointer w-full h-full focus:outline-none`}
         onClick={handleSelectBarClick}
       >
         <div className="flex justify-between items-center">
           <p
-            className={`text-14-m ${!value ? "text-slate-400" : "text-gray-900"}`}
+            className={`${textClassName} ${!value ? "text-slate-400" : noBorder ? "text-cyan-600" : "text-gray-900"}`}
           >
             {value || placeholder}
           </p>
           <img
             src={chevronDown}
-            className={`transform transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+            className={`transform transition-transform duration-200 ${isOpen ? "rotate-180" : ""} ${noBorder ? "ml-3" : ""}`}
             alt="chevron"
           />
         </div>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,22 +1,14 @@
 interface TagProps {
   label: string;
-  onClick?: () => void;
   onRemove?: () => void;
 }
 
-export default function Tag({ label, onClick, onRemove }: TagProps) {
+export default function Tag({ label, onRemove }: TagProps) {
   return (
     <div
       className={`w-fit h-8 px-2 py-1 rounded-lg bg-slate-100 flex items-center gap-1`}
     >
-      <p
-        className={`text-16-m text-slate-500 ${
-          onClick ? "cursor-pointer" : ""
-        }`}
-        onClick={onClick}
-      >
-        {label}
-      </p>
+      <p className={`text-16-m text-slate-500`}>{label}</p>
       {onRemove && (
         <button
           type="button"

--- a/src/components/dropdown/DropdownItem.tsx
+++ b/src/components/dropdown/DropdownItem.tsx
@@ -6,7 +6,7 @@ interface DropdownItemProps {
 export default function DropdownItem({ label, onClick }: DropdownItemProps) {
   return (
     <li
-      className={`h-11 p-3 gap-0.5 bg-white font-pretendard font-medium text-sm leading-5 hover:bg-slate-100`}
+      className={`h-11 p-3 gap-0.5 bg-white font-pretendard font-medium text-sm leading-5 hover:bg-slate-100 truncate`}
       onClick={onClick}
     >
       <span>{label}</span>

--- a/src/components/modal/ArticleDetailModal.tsx
+++ b/src/components/modal/ArticleDetailModal.tsx
@@ -1,0 +1,342 @@
+import ModalLayout from "./ModalLayout";
+import type { ArticleListItem } from "@/api/articles/types";
+import Button from "../button/Button";
+import SelectBox from "../SelectBox";
+import Input from "../Input";
+import CommentCard from "@/features/comments/components/CommentCard";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  addLikeComment,
+  createComment,
+  deleteComment,
+  deleteLikeComment,
+  getComments,
+  updateComment,
+} from "@/api/comments";
+import { useAuthInfo } from "@/features/auth/hooks/useAuthInfo";
+import type { CommentItem, CommentsOrderBy } from "@/api/comments/types";
+import type { CommentId } from "@/types/ids";
+import { toast } from "react-toastify";
+import type { SortDirection } from "@/types/direction";
+import { format } from "date-fns";
+import Label from "../Label";
+import naverLogo from "@/assets/logos/news/naver.svg";
+import chosunLogo from "@/assets/logos/news/chosun-ilbo.svg";
+import koreanLogo from "@/assets/logos/news/korean-economy.svg";
+import yonhapLogo from "@/assets/logos/news/yonhap-news.svg";
+import commentIcon from "@/assets/icons/comment.svg";
+import useConfirmModal from "@/shared/hooks/useConfirmModal";
+import ConfirmModal from "./ConfirmModal";
+
+interface ArticleDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  data: ArticleListItem | null;
+}
+
+const SOURCE_LOGOS = {
+  NAVER: naverLogo,
+  YONHAP: yonhapLogo,
+  CHOSUN: chosunLogo,
+  KOREAN: koreanLogo,
+} as const;
+
+export default function ArticleDetailModal({
+  isOpen,
+  onClose,
+  data,
+}: ArticleDetailModalProps) {
+  const commentItems = ["등록순", "좋아요순"];
+
+  const limit = 5;
+  const [orderBy, setOrderBy] = useState<CommentsOrderBy>("createdAt");
+  const orderByDisplayValue = orderBy === "createdAt" ? "등록순" : "좋아요순";
+  const direction = "DESC" as SortDirection;
+
+  const [comments, setComments] = useState<CommentItem[]>([]);
+
+  const [writtenComment, setWrittenComment] = useState("");
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasNext, setHasNext] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+
+  const observerRef = useRef<IntersectionObserver>(null);
+  const lastElementRef = useRef<HTMLDivElement>(null);
+
+  const {
+    isOpen: isConfirmOpen,
+    openModal: openConfirmModal,
+    onClose: closeConfirmModal,
+    initialData: confirmData,
+  } = useConfirmModal();
+
+  const { userId } = useAuthInfo();
+
+  const fetchInitialData = useCallback(async () => {
+    setIsLoading(true);
+    if (!data) return;
+    try {
+      const params = {
+        articleId: data.id,
+        orderBy,
+        direction,
+        limit,
+      };
+      const response = await getComments(params, userId);
+      setComments(response.content);
+      setHasNext(response.hasNext);
+      setNextCursor(response.nextCursor);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [data, orderBy, userId]);
+
+  const fetchMoreData = useCallback(async () => {
+    if (!data || !hasNext || !userId || isLoading) return;
+
+    setIsLoading(true);
+
+    try {
+      const params = {
+        articleId: data.id,
+        orderBy,
+        direction,
+        limit,
+        cursor: nextCursor || undefined,
+      };
+      const response = await getComments(params, userId);
+      setComments((prev) => [...prev, ...response.content]);
+      setHasNext(response.hasNext);
+      setNextCursor(response.nextCursor);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [orderBy, direction, limit, nextCursor, data, hasNext, isLoading, userId]);
+
+  useEffect(() => {
+    fetchInitialData();
+  }, [fetchInitialData]);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNext) {
+          fetchMoreData();
+        }
+      },
+      {
+        threshold: 0.8,
+      },
+    );
+    if (lastElementRef.current) {
+      observerRef.current.observe(lastElementRef.current);
+    }
+
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+    };
+  }, [hasNext, isLoading, fetchMoreData]);
+
+  const handleClick = () => {
+    if (data) {
+      window.open(data.sourceUrl, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  const handleApplyFilters = (value: string) => {
+    if (value === "등록순") {
+      setOrderBy("createdAt");
+    } else if (value === "좋아요순") {
+      setOrderBy("likeCount");
+    }
+  };
+
+  const handleLikeClick = async (commentId: CommentId) => {
+    try {
+      const comment = comments.find((c) => c.id === commentId);
+      if (!comment) return;
+
+      if (comment.likedByMe) {
+        await deleteLikeComment(commentId, userId);
+      } else {
+        await addLikeComment(commentId, userId);
+      }
+
+      await fetchInitialData();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleEditSave = async (commentId: CommentId, newContent: string) => {
+    try {
+      await updateComment(commentId, { content: newContent }, userId);
+
+      fetchInitialData();
+      toast.success("댓글이 수정되었습니다.");
+    } catch (error) {
+      console.error(error);
+      toast.error("댓글 수정 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleAddComment = async (content: string) => {
+    if (!data || !content.trim()) return;
+
+    try {
+      const params = {
+        articleId: data.id,
+        userId,
+        content: content.trim(),
+      };
+      await createComment(params);
+
+      setWrittenComment("");
+      await fetchInitialData();
+      toast.success("댓글 작성 완료");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleDeleteComment = async (commentId: CommentId) => {
+    openConfirmModal({
+      title: "댓글 삭제",
+      message: "정말 삭제하시겠습니까?",
+      onConfirm: async () => {
+        try {
+          await deleteComment(commentId);
+          toast.success("댓글이 삭제되었습니다.");
+          await fetchInitialData();
+        } catch (error) {
+          console.error(error);
+          toast.error("댓글 삭제 중 오류가 발생했습니다.");
+        }
+      },
+      confirmText: "삭제",
+      cancelText: "취소",
+    });
+  };
+
+  if (!isOpen || !data) return;
+
+  const formattedDate = format(data.publishDate, "yyyy.MM.dd");
+  const labelSrc = SOURCE_LOGOS[data.source as keyof typeof SOURCE_LOGOS] || "";
+
+  return (
+    <ModalLayout
+      isOpen={isOpen}
+      onClose={onClose}
+      width="w-[894px]"
+      noPadding={true}
+    >
+      <div className="h-auto rounded-tr-3xl rounded-tl-3xl pt-10 px-10 pb-6 bg-white">
+        <div className="text-20-b text-slate-900 mb-2">{data.title}</div>
+
+        <div className="flex items-center gap-4  pb-6 mb-6 border-b border-slate-200">
+          <Label src={labelSrc} label={data.source} />
+          <div className="flex items-center gap-3">
+            <span className="text-14-r text-slate-400">{formattedDate}</span>
+            <span className="text-slate-300">|</span>
+            <div className="flex items-center gap-1">
+              <span className="text-14-r text-slate-400">읽음</span>
+              <span className="text-14-r text-slate-400">{data.viewCount}</span>
+            </div>
+            <span className="text-slate-300">|</span>
+            <div className="flex items-center gap-1">
+              <img src={commentIcon} className="w-5 h-5" alt="댓글" />
+              <span className="text-14-r text-slate-400">
+                {data.commentCount}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="text-18-r text-slate-500 mb-6">{data.summary}</div>
+
+        <div className="mt-4 mb-10 border-b-slate-200">
+          <Button
+            size="sm"
+            className="w-[162px]"
+            variant="secondary"
+            onClick={handleClick}
+          >
+            전체 기사 보러가기 →
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-br-3xl rounded-bl-3xl pt-3 px-10 pb-8 bg-slate-100">
+        <div className="mb-2 w-[110px]">
+          <SelectBox
+            items={commentItems}
+            value={orderByDisplayValue}
+            onChange={handleApplyFilters}
+            placeholder="등록순"
+            noBorder={true}
+            textClassName="text-14-m text-slate-400"
+            noBackground={true}
+          />
+        </div>
+        <div className="flex items-center gap-2.5 mb-2">
+          <Input
+            placeholder="2025.01.01 부터"
+            className="flex-1"
+            value={writtenComment}
+            onChange={(e) => setWrittenComment(e.target.value)}
+          />
+          <Button
+            className="w-[92px]"
+            onClick={() => handleAddComment(writtenComment)}
+          >
+            댓글 작성
+          </Button>
+        </div>
+        <div>
+          {comments.map((comment, index) => (
+            <div
+              key={comment.id}
+              ref={index === comments.length - 1 ? lastElementRef : null}
+            >
+              <CommentCard
+                userNickname={comment.userNickname}
+                createdAt={new Date(comment.createdAt)}
+                likeCount={comment.likeCount}
+                content={comment.content}
+                isLiked={comment.likedByMe}
+                onLikeClick={handleLikeClick}
+                onEditSave={handleEditSave}
+                commentId={comment.id}
+                isMyComment={comment.userId === userId}
+                onDelete={handleDeleteComment}
+              />
+            </div>
+          ))}
+          {confirmData && (
+            <ConfirmModal
+              isOpen={isConfirmOpen}
+              onClose={closeConfirmModal}
+              onConfirm={confirmData.onConfirm}
+              title={confirmData.title}
+              message={confirmData.message}
+              confirmText={confirmData.confirmText}
+              cancelText={confirmData.cancelText}
+            />
+          )}
+        </div>
+      </div>
+    </ModalLayout>
+  );
+}

--- a/src/components/modal/ArticleDetailModal.tsx
+++ b/src/components/modal/ArticleDetailModal.tsx
@@ -217,8 +217,12 @@ export default function ArticleDetailModal({
       title: "댓글 삭제",
       message: "정말 삭제하시겠습니까?",
       onConfirm: async () => {
+        console.log("onConfirm 함수 실행 시작");
+
         try {
+          console.log("deleteComment 호출 전");
           await deleteComment(commentId);
+          console.log("deleteComment 호출 후");
           toast.success("댓글이 삭제되었습니다.");
           await fetchInitialData();
         } catch (error) {
@@ -237,106 +241,111 @@ export default function ArticleDetailModal({
   const labelSrc = SOURCE_LOGOS[data.source as keyof typeof SOURCE_LOGOS] || "";
 
   return (
-    <ModalLayout
-      isOpen={isOpen}
-      onClose={onClose}
-      width="w-[894px]"
-      noPadding={true}
-    >
-      <div className="h-auto rounded-tr-3xl rounded-tl-3xl pt-10 px-10 pb-6 bg-white">
-        <div className="text-20-b text-slate-900 mb-2">{data.title}</div>
+    <>
+      <ModalLayout
+        isOpen={isOpen}
+        onClose={onClose}
+        width="w-[894px]"
+        noPadding={true}
+        disableClose={isConfirmOpen}
+      >
+        <div className="h-auto rounded-tr-3xl rounded-tl-3xl pt-10 px-10 pb-6 bg-white">
+          <div className="text-20-b text-slate-900 mb-2">{data.title}</div>
 
-        <div className="flex items-center gap-4  pb-6 mb-6 border-b border-slate-200">
-          <Label src={labelSrc} label={data.source} />
-          <div className="flex items-center gap-3">
-            <span className="text-14-r text-slate-400">{formattedDate}</span>
-            <span className="text-slate-300">|</span>
-            <div className="flex items-center gap-1">
-              <span className="text-14-r text-slate-400">읽음</span>
-              <span className="text-14-r text-slate-400">{data.viewCount}</span>
-            </div>
-            <span className="text-slate-300">|</span>
-            <div className="flex items-center gap-1">
-              <img src={commentIcon} className="w-5 h-5" alt="댓글" />
-              <span className="text-14-r text-slate-400">
-                {data.commentCount}
-              </span>
+          <div className="flex items-center gap-4  pb-6 mb-6 border-b border-slate-200">
+            <Label src={labelSrc} label={data.source} />
+            <div className="flex items-center gap-3">
+              <span className="text-14-r text-slate-400">{formattedDate}</span>
+              <span className="text-slate-300">|</span>
+              <div className="flex items-center gap-1">
+                <span className="text-14-r text-slate-400">읽음</span>
+                <span className="text-14-r text-slate-400">
+                  {data.viewCount}
+                </span>
+              </div>
+              <span className="text-slate-300">|</span>
+              <div className="flex items-center gap-1">
+                <img src={commentIcon} className="w-5 h-5" alt="댓글" />
+                <span className="text-14-r text-slate-400">
+                  {data.commentCount}
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div className="text-18-r text-slate-500 mb-6">{data.summary}</div>
+          <div className="text-18-r text-slate-500 mb-6">{data.summary}</div>
 
-        <div className="mt-4 mb-10 border-b-slate-200">
-          <Button
-            size="sm"
-            className="w-[162px]"
-            variant="secondary"
-            onClick={handleClick}
-          >
-            전체 기사 보러가기 →
-          </Button>
-        </div>
-      </div>
-
-      <div className="rounded-br-3xl rounded-bl-3xl pt-3 px-10 pb-8 bg-slate-100">
-        <div className="mb-2 w-[110px]">
-          <SelectBox
-            items={commentItems}
-            value={orderByDisplayValue}
-            onChange={handleApplyFilters}
-            placeholder="등록순"
-            noBorder={true}
-            textClassName="text-14-m text-slate-400"
-            noBackground={true}
-          />
-        </div>
-        <div className="flex items-center gap-2.5 mb-2">
-          <Input
-            placeholder="2025.01.01 부터"
-            className="flex-1"
-            value={writtenComment}
-            onChange={(e) => setWrittenComment(e.target.value)}
-          />
-          <Button
-            className="w-[92px]"
-            onClick={() => handleAddComment(writtenComment)}
-          >
-            댓글 작성
-          </Button>
-        </div>
-        <div>
-          {comments.map((comment, index) => (
-            <div
-              key={comment.id}
-              ref={index === comments.length - 1 ? lastElementRef : null}
+          <div className="mt-4 mb-10 border-b-slate-200">
+            <Button
+              size="sm"
+              className="w-[162px]"
+              variant="secondary"
+              onClick={handleClick}
             >
-              <CommentCard
-                userNickname={comment.userNickname}
-                createdAt={new Date(comment.createdAt)}
-                likeCount={comment.likeCount}
-                content={comment.content}
-                isLiked={comment.likedByMe}
-                onLikeClick={handleLikeClick}
-                onEditSave={handleEditSave}
-                commentId={comment.id}
-                isMyComment={comment.userId === userId}
-                onDelete={handleDeleteComment}
-              />
-            </div>
-          ))}
-          {confirmData && (
-            <ConfirmModal
-              isOpen={isConfirmOpen}
-              onClose={closeConfirmModal}
-              onConfirm={confirmData.onConfirm}
-              title={confirmData.title}
-              message={confirmData.message}
-              confirmText={confirmData.confirmText}
-              cancelText={confirmData.cancelText}
-            />
-          )}
+              전체 기사 보러가기 →
+            </Button>
+          </div>
         </div>
-      </div>
-    </ModalLayout>
+
+        <div className="rounded-br-3xl rounded-bl-3xl pt-3 px-10 pb-8 bg-slate-100">
+          <div className="mb-2 w-[110px]">
+            <SelectBox
+              items={commentItems}
+              value={orderByDisplayValue}
+              onChange={handleApplyFilters}
+              placeholder="등록순"
+              noBorder={true}
+              textClassName="text-14-m text-slate-400"
+              noBackground={true}
+            />
+          </div>
+          <div className="flex items-center gap-2.5 mb-2">
+            <Input
+              placeholder="2025.01.01 부터"
+              className="flex-1"
+              value={writtenComment}
+              onChange={(e) => setWrittenComment(e.target.value)}
+            />
+            <Button
+              className="w-[92px]"
+              onClick={() => handleAddComment(writtenComment)}
+            >
+              댓글 작성
+            </Button>
+          </div>
+          <div>
+            {comments.map((comment, index) => (
+              <div
+                key={comment.id}
+                ref={index === comments.length - 1 ? lastElementRef : null}
+              >
+                <CommentCard
+                  userNickname={comment.userNickname}
+                  createdAt={new Date(comment.createdAt)}
+                  likeCount={comment.likeCount}
+                  content={comment.content}
+                  isLiked={comment.likedByMe}
+                  onLikeClick={handleLikeClick}
+                  onEditSave={handleEditSave}
+                  commentId={comment.id}
+                  isMyComment={comment.userId === userId}
+                  onDelete={handleDeleteComment}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </ModalLayout>
+      {confirmData && (
+        <ConfirmModal
+          isOpen={isConfirmOpen}
+          onClose={closeConfirmModal}
+          onConfirm={confirmData.onConfirm}
+          title={confirmData.title}
+          message={confirmData.message}
+          confirmText={confirmData.confirmText}
+          cancelText={confirmData.cancelText}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/modal/ConfirmModal.tsx
+++ b/src/components/modal/ConfirmModal.tsx
@@ -4,7 +4,7 @@ import ModalLayout from "./ModalLayout";
 interface ConfirmModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
   title: string;
   message: string;
   confirmText?: string;
@@ -21,8 +21,8 @@ export default function ConfirmModal({
   cancelText = "취소",
   confirmText = "확인",
 }: ConfirmModalProps) {
-  const handleConfirm = () => {
-    onConfirm();
+  const handleConfirm = async () => {
+    await onConfirm();
     onClose();
   };
 

--- a/src/components/modal/ModalLayout.tsx
+++ b/src/components/modal/ModalLayout.tsx
@@ -8,6 +8,7 @@ interface ModalLayoutProps {
   children: React.ReactNode;
   width?: string;
   noPadding?: boolean;
+  disableClose?: boolean;
 }
 
 export default function ModalLayout({
@@ -16,10 +17,11 @@ export default function ModalLayout({
   children,
   width = "w-[502px]",
   noPadding = false,
+  disableClose = false,
 }: ModalLayoutProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
-  useClosePopup(modalRef, onClose, isOpen);
+  useClosePopup(modalRef, onClose, isOpen, disableClose);
 
   // 모달 열릴 때 body 스크롤 막기
   useEffect(() => {
@@ -39,7 +41,7 @@ export default function ModalLayout({
 
   return createPortal(
     <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center"
       role="dialog"
       aria-modal="true"
     >

--- a/src/components/modal/ModalLayout.tsx
+++ b/src/components/modal/ModalLayout.tsx
@@ -1,21 +1,39 @@
 import { useClosePopup } from "@/shared/hooks/useClosePopup";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
 interface ModalLayoutProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  width?: string;
+  noPadding?: boolean;
 }
 
 export default function ModalLayout({
   isOpen,
   onClose,
   children,
+  width = "w-[502px]",
+  noPadding = false,
 }: ModalLayoutProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useClosePopup(modalRef, onClose, isOpen);
+
+  // 모달 열릴 때 body 스크롤 막기
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
+    }
+
+    // cleanup: 컴포넌트 언마운트 시 원복
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -26,7 +44,8 @@ export default function ModalLayout({
       aria-modal="true"
     >
       <div
-        className="w-[502px] min-h-80 h-auto rounded-2xl p-8 gap-2.5 bg-white relative"
+        ref={modalRef}
+        className={`${width} max-h-[90vh] overflow-y-auto h-auto rounded-2xl ${noPadding ? "" : "p-8"} gap-2.5 bg-white relative`}
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -39,6 +58,6 @@ export default function ModalLayout({
         {children}
       </div>
     </div>,
-    document.body
+    document.body,
   );
 }

--- a/src/features/articles/components/NewsCard.tsx
+++ b/src/features/articles/components/NewsCard.tsx
@@ -5,15 +5,12 @@ import koreanLogo from "@/assets/logos/news/korean-economy.svg";
 import yonhapLogo from "@/assets/logos/news/yonhap-news.svg";
 import commentIcon from "@/assets/icons/comment.svg";
 import { format } from "date-fns";
+import useArticleDetailModal from "@/shared/hooks/useArticleDetailModal";
+import type { ArticleListItem } from "@/api/articles/types";
+import ArticleDetailModal from "@/components/modal/ArticleDetailModal";
 
 interface NewsCardProps {
-  title: string;
-  summary: string;
-  source: string;
-  sourceUrl: string;
-  publishDate: Date;
-  viewCount: number;
-  commentCount: number;
+  article: ArticleListItem;
 }
 
 const SOURCE_LOGOS = {
@@ -23,48 +20,54 @@ const SOURCE_LOGOS = {
   KOREAN: koreanLogo,
 } as const;
 
-export default function NewsCard({
-  title,
-  summary,
-  source,
-  sourceUrl,
-  publishDate,
-  viewCount,
-  commentCount,
-}: NewsCardProps) {
-  const labelSrc = SOURCE_LOGOS[source as keyof typeof SOURCE_LOGOS] || "";
+export default function NewsCard({ article }: NewsCardProps) {
+  const labelSrc =
+    SOURCE_LOGOS[article.source as keyof typeof SOURCE_LOGOS] || "";
 
-  const formattedDate = format(publishDate, "yyyy.MM.dd");
+  const formattedDate = format(article.publishDate, "yyyy.MM.dd");
+
+  const { isOpen, openModal, onClose, initialData } = useArticleDetailModal();
 
   const handleClick = () => {
-    window.open(sourceUrl, "_blank", "noopener,noreferrer");
+    openModal(article);
   };
 
   return (
-    <div
-      className="max-w-4xl w-auto min-h-48 h-auto cursor-pointer"
-      onClick={handleClick}
-    >
-      <div className="my-6 mx-1">
-        <div className="text-20-b text-slate-900 mb-2">{title}</div>
-        <div className="text-18-r text-slate-500 mb-6">{summary}</div>
-        <div className="flex justify-between items-center">
-          <Label src={labelSrc} label={source} />
-          <div className="flex items-center gap-3">
-            <span className="text-14-r text-slate-400">{formattedDate}</span>
-            <span className="text-slate-300">|</span>
-            <div className="flex items-center gap-1">
-              <span className="text-14-r text-slate-400">읽음</span>
-              <span className="text-14-r text-slate-400">{viewCount}</span>
-            </div>
-            <span className="text-slate-300">|</span>
-            <div className="flex items-center gap-1">
-              <img src={commentIcon} className="w-5 h-5" alt="댓글" />
-              <span className="text-14-r text-slate-400">{commentCount}</span>
+    <>
+      <div
+        className="max-w-4xl w-auto min-h-48 h-auto cursor-pointer"
+        onClick={handleClick}
+      >
+        <div className="my-6 mx-1">
+          <div className="text-20-b text-slate-900 mb-2">{article.title}</div>
+          <div className="text-18-r text-slate-500 mb-6">{article.summary}</div>
+          <div className="flex justify-between items-center">
+            <Label src={labelSrc} label={article.source} />
+            <div className="flex items-center gap-3">
+              <span className="text-14-r text-slate-400">{formattedDate}</span>
+              <span className="text-slate-300">|</span>
+              <div className="flex items-center gap-1">
+                <span className="text-14-r text-slate-400">읽음</span>
+                <span className="text-14-r text-slate-400">
+                  {article.viewCount}
+                </span>
+              </div>
+              <span className="text-slate-300">|</span>
+              <div className="flex items-center gap-1">
+                <img src={commentIcon} className="w-5 h-5" alt="댓글" />
+                <span className="text-14-r text-slate-400">
+                  {article.commentCount}
+                </span>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+      <ArticleDetailModal
+        isOpen={isOpen}
+        onClose={onClose}
+        data={initialData}
+      />
+    </>
   );
 }

--- a/src/features/comments/components/CommentCard.tsx
+++ b/src/features/comments/components/CommentCard.tsx
@@ -5,7 +5,10 @@ import { ko } from "date-fns/locale";
 import type { CommentId } from "@/types/ids";
 import Input from "../../../components/Input";
 import Button from "../../../components/button/Button";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import kebabIcon from "@/assets/icons/kebab-menu-20.svg";
+import { useClosePopup } from "@/shared/hooks/useClosePopup";
+import Dropdown from "@/components/dropdown";
 
 interface CommentCardProps {
   userNickname: string;
@@ -17,6 +20,7 @@ interface CommentCardProps {
   isMyComment: boolean;
   onLikeClick: (commentId: CommentId) => void;
   onEditSave: (commentId: CommentId, newContent: string) => void;
+  onDelete: (commentId: CommentId) => void;
   className?: string;
 }
 
@@ -28,20 +32,24 @@ export default function CommentCard({
   isLiked,
   onLikeClick,
   onEditSave,
+  onDelete,
   commentId,
   isMyComment,
   className,
 }: CommentCardProps) {
   const [commentValue, setCommentValue] = useState(content);
   const [isEditing, setIsEditing] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const kebabRef = useRef<HTMLButtonElement>(null);
+
+  useClosePopup(kebabRef, () => setIsDropdownOpen(false), isDropdownOpen);
 
   const handleHeartClick = () => {
     onLikeClick(commentId);
   };
 
-  const handleEditClick = () => {
-    setIsEditing(true);
-    setCommentValue(content);
+  const handleKebabClick = () => {
+    setIsDropdownOpen(!isDropdownOpen);
   };
 
   const handleCancelEdit = () => {
@@ -56,6 +64,15 @@ export default function CommentCard({
     }
   };
 
+  const handleDropdownChange = (value: string) => {
+    if (value === "수정하기") {
+      setIsEditing(true);
+      setCommentValue(content);
+    } else if (value === "삭제하기") {
+      onDelete(commentId);
+    }
+  };
+
   return (
     <div
       className={`w-full h-auto border-slate-300 py-4 px-4 bg-slate-100 rounded-lg ${className || ""}`}
@@ -67,16 +84,30 @@ export default function CommentCard({
           <span className="text-14-m text-slate-500">
             {formatDistanceToNow(createdAt, { addSuffix: true, locale: ko })}
           </span>
+          {isMyComment && (
+            <span className="ml-1 text-14-m text-cyan-500">내 댓글</span>
+          )}
         </div>
 
         <div className="flex items-center gap-2">
           {/* 본인 댓글이고 수정 모드가 아닐 때 수정 버튼 나오게 */}
           {isMyComment && !isEditing && (
             <button
-              onClick={handleEditClick}
-              className="text-14-r text-slate-400 hover:text-slate-600"
+              ref={kebabRef}
+              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
             >
-              수정
+              <img
+                src={kebabIcon}
+                className="w-5 h-5"
+                alt="케밥"
+                onClick={handleKebabClick}
+              />
+              {isDropdownOpen && (
+                <Dropdown
+                  items={["수정하기", "삭제하기"]}
+                  onChange={handleDropdownChange}
+                />
+              )}
             </button>
           )}
 

--- a/src/features/interests/components/InterestCard.tsx
+++ b/src/features/interests/components/InterestCard.tsx
@@ -73,7 +73,7 @@ export default function InterestCard({
   };
 
   return (
-    <div className="w-full h-auto border border-slate-200 rounded-2xl p-6 bg-white">
+    <div className="w-full h-[232px] border border-slate-200 rounded-2xl p-6 bg-white flex flex-col">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-20-b text-slate-900">{name}</h2>
         <button
@@ -92,11 +92,11 @@ export default function InterestCard({
         </button>
       </div>
 
-      <div className="flex flex-wrap gap-2 mb-6">
+      <div className="flex flex-wrap gap-2 mb-6 flex-1 overflow-y-auto">
         {keywords.map((keyword, index) => (
           <div
             key={index}
-            className="rounded-lg py-1 px-2 bg-slate-100 text-16-m text-slate-500"
+            className="rounded-lg py-1 px-2 bg-slate-100 text-16-m text-slate-500 h-fit"
           >
             {keyword}
           </div>

--- a/src/pages/ArticlesPage.tsx
+++ b/src/pages/ArticlesPage.tsx
@@ -1,7 +1,458 @@
+import { getArticles, restoreArticles } from "@/api/articles";
+import type {
+  ArticleListItem,
+  ArticlesOrderBy,
+  RestoreArticlesParams,
+} from "@/api/articles/types";
+import { getInterests } from "@/api/interests";
+import type { InterestListItem, InterestOrderBy } from "@/api/interests/types";
+import Button from "@/components/button/Button";
+import EmptyState from "@/components/EmptyState";
+import Input from "@/components/Input";
+import ArticleModal from "@/components/modal/ArticleModal";
+import SearchBar from "@/components/SearchBar";
+import SelectBox from "@/components/SelectBox";
+import NewsCard from "@/features/articles/components/NewsCard";
+import { useAuthInfo } from "@/features/auth/hooks/useAuthInfo";
+import useArticleRecoveryModal from "@/shared/hooks/useArticleRecoveryModal";
+import type { SortDirection } from "@/types/direction";
+import type { InterestId } from "@/types/ids";
+import type { AxiosError } from "axios";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { toast } from "react-toastify";
+
+interface ApiErrorResponse {
+  message: string;
+  code: string;
+  timestamp: string;
+  details?: Record<string, unknown>;
+  exceptionType?: string;
+  status?: number;
+}
+
+const INTEREST_ORDER_BY = "name" as InterestOrderBy;
+const INTEREST_DIRECTION = "DESC" as SortDirection;
+const INTEREST_LIMIT = 9999;
+
 function ArticlesPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const sortOptions = ["게시일", "조회수", "댓글수"];
+  const directionOptions = ["내림차순", "오름차순"];
+
+  const orderByParam =
+    (searchParams.get("orderBy") as ArticlesOrderBy) || "publishDate";
+  const orderBy =
+    orderByParam === "publishDate" ||
+    orderByParam === "commentCount" ||
+    orderByParam === "viewCount"
+      ? orderByParam
+      : "publishDate";
+
+  const directionBy =
+    (searchParams.get("direction") as SortDirection) || "DESC";
+  const direction =
+    directionBy === "ASC" || directionBy === "DESC" ? directionBy : "DESC";
+
+  const limit = searchParams.get("limit") || "5";
+  const keyword = searchParams.get("keyword") || "";
+  const interestId = (searchParams.get("interestId") as InterestId) || "";
+
+  const [selectedInterest, setSelectedInterest] = useState("");
+
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+  const publishDateFrom = searchParams.get("publishDateFrom") || "";
+  const publishDateTo = searchParams.get("publishDateTo") || "";
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasNext, setHasNext] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+
+  const observerRef = useRef<IntersectionObserver>(null);
+  const lastElementRef = useRef<HTMLDivElement>(null);
+
+  const [articles, setArticles] = useState<ArticleListItem[]>([]);
+  const [interests, setInterests] = useState<InterestListItem[]>([]);
+
+  const navigate = useNavigate();
+
+  const { userId } = useAuthInfo();
+
+  const { isOpen, openModal, onClose } = useArticleRecoveryModal();
+
+  const sortMap: Record<string, string> = {
+    게시일: "publishDate",
+    조회수: "viewCount",
+    댓글수: "commentCount",
+  };
+
+  const reverseSortMap: Record<string, string> = {
+    publishDate: "게시일",
+    viewCount: "조회수",
+    commentCount: "댓글수",
+  };
+
+  const [sortValue, setSortValue] = useState(
+    reverseSortMap[orderBy] || "게시일",
+  );
+  const [directionValue, setDirectionValue] = useState(
+    direction === "DESC" ? "내림차순" : "오름차순",
+  );
+
+  const fetchInitialData = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const params = {
+        keyword,
+        interestId,
+        publishDateFrom,
+        publishDateTo,
+        orderBy,
+        direction,
+        limit: parseInt(limit),
+      };
+
+      const response = await getArticles(params, userId);
+      setHasNext(response.hasNext);
+      setNextCursor(response.nextCursor);
+      setArticles(response.content);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    keyword,
+    interestId,
+    orderBy,
+    direction,
+    publishDateFrom,
+    publishDateTo,
+    limit,
+    userId,
+  ]);
+
+  const fetchMoreData = useCallback(async () => {
+    if (!hasNext || !userId || isLoading) return;
+
+    setIsLoading(true);
+
+    try {
+      const params = {
+        keyword,
+        interestId,
+        publishDateFrom,
+        publishDateTo,
+        orderBy,
+        direction,
+        limit: parseInt(limit),
+        cursor: nextCursor || undefined,
+      };
+
+      const response = await getArticles(params, userId);
+      setArticles((prev) => [...prev, ...response.content]);
+      setHasNext(response.hasNext);
+      setNextCursor(response.nextCursor);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    orderBy,
+    direction,
+    publishDateFrom,
+    publishDateTo,
+    limit,
+    keyword,
+    interestId,
+    userId,
+    hasNext,
+    isLoading,
+    nextCursor,
+  ]);
+
+  const fetchInterestData = useCallback(async () => {
+    try {
+      const interestParams = {
+        orderBy: INTEREST_ORDER_BY,
+        direction: INTEREST_DIRECTION,
+        limit: INTEREST_LIMIT,
+      };
+
+      const response = await getInterests(interestParams, userId);
+      setInterests(response.content);
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNext) {
+          fetchMoreData();
+        }
+      },
+      {
+        threshold: 0.8,
+      },
+    );
+    if (lastElementRef.current) {
+      observerRef.current.observe(lastElementRef.current);
+    }
+
+    return () => {
+      if (observerRef.current) observerRef.current.disconnect();
+    };
+  }, [hasNext, isLoading, fetchMoreData]);
+
+  const interestNames = useMemo(
+    () => interests.map((interest) => interest.name),
+    [interests],
+  );
+
+  const handleInterestChange = (value: string) => {
+    setSelectedInterest(value);
+    const selectedInterestData = interests.find(
+      (interest) => interest.name === value,
+    );
+
+    if (selectedInterestData) {
+      setSearchParams((prev) => {
+        const newParams = new URLSearchParams(prev);
+        newParams.set("interestId", selectedInterestData.id);
+        return newParams;
+      });
+      setNextCursor(null);
+      setHasNext(false);
+    }
+  };
+
+  const handleSortOption = (value: string) => {
+    setSortValue(value);
+  };
+  const handleDirectionOption = (value: string) => {
+    setDirectionValue(value);
+  };
+
+  const handleSearch = (searchKeyword: string) => {
+    if ((searchKeyword ?? "") === keyword) return;
+
+    setSearchParams((prev) => {
+      const newParams = new URLSearchParams(prev);
+      if (searchKeyword) {
+        newParams.set("keyword", searchKeyword);
+      } else {
+        newParams.delete("keyword");
+      }
+      newParams.delete("interestId");
+      return newParams;
+    });
+    setSelectedInterest("");
+    setNextCursor(null);
+    setHasNext(false);
+  };
+
+  const handleApplyFilters = () => {
+    setSearchParams((prev) => {
+      const newParams = new URLSearchParams(prev);
+      newParams.set("orderBy", sortMap[sortValue]);
+
+      newParams.set(
+        "direction",
+        directionValue === "오름차순" ? "ASC" : "DESC",
+      );
+
+      if (fromDate) {
+        newParams.set(
+          "publishDateFrom",
+          `${fromDate.replace(/\./g, "-")}T00:00:00`,
+        );
+      } else {
+        newParams.delete("publishDateFrom");
+      }
+      if (toDate) {
+        newParams.set(
+          "publishDateTo",
+          `${toDate.replace(/\./g, "-")}T23:59:59`,
+        );
+      } else {
+        newParams.delete("publishDateTo");
+      }
+
+      if (interestId) {
+        newParams.set("interestId", interestId);
+      } else {
+        newParams.delete("interestId");
+      }
+
+      return newParams;
+    });
+    setNextCursor(null);
+    setHasNext(false);
+  };
+
+  useEffect(() => {
+    fetchInterestData();
+  }, [fetchInterestData]);
+
+  useEffect(() => {
+    setSortValue(reverseSortMap[orderBy] || "게시일");
+    setDirectionValue(direction === "DESC" ? "내림차순" : "오름차순");
+    fetchInitialData();
+  }, [fetchInitialData, orderBy, direction]);
+
+  const handleRestoreArticle = (data: RestoreArticlesParams) => {
+    try {
+      const formattedData = {
+        from: `${data.from.replace(/\./g, "-")}T00:00:00`,
+        to: `${data.to.replace(/\./g, "-")}T23:59:59`,
+      };
+
+      restoreArticles(formattedData);
+
+      fetchInitialData();
+
+      toast.success("기사가 복구되었습니다.");
+
+      onClose();
+    } catch (error) {
+      console.error(error);
+
+      const axiosError = error as AxiosError<ApiErrorResponse>;
+      const errorMessage =
+        axiosError.response?.data?.message ||
+        axiosError.message ||
+        "오류가 발생했습니다.";
+
+      toast.error(errorMessage);
+    }
+  };
+
   return (
-    <div>
-      <h1>Articles</h1>
+    <div className="flex gap-12 mt-15 justify-center">
+      <div className="max-w-3xs min-h-[564px] h-auto">
+        <div className="mb-6">
+          <SearchBar height="h-11" onSearch={handleSearch} />
+        </div>
+        <div className="h-auto mb-6 border border-slate-200 rounded-2xl px-4 pt-4 pb-6 bg-white">
+          <div className="text-14-m text-slate-900 mb-2">정렬</div>
+          <div className="min-h-10">
+            <SelectBox
+              items={sortOptions}
+              value={sortValue}
+              onChange={handleSortOption}
+              className="mb-6 h-10"
+            />
+          </div>
+
+          <div className="text-14-m text-slate-900 mb-2">정렬 방향</div>
+          <SelectBox
+            items={directionOptions}
+            value={directionValue}
+            onChange={handleDirectionOption}
+            className="mb-6 h-10"
+          />
+          <div className="text-14-m text-slate-900 mb-2">출처</div>
+          <Input value="NAVER" className="mb-6" inputSize="sm" disabled />
+
+          <div className="text-14-m text-slate-900 mb-2">날짜</div>
+          <Input
+            value={fromDate}
+            placeholder="2025.01.01 부터"
+            onChange={(e) => setFromDate(e.target.value)}
+            className="mb-2"
+            inputSize="sm"
+          />
+          <Input
+            value={toDate}
+            placeholder="2025.01.01 까지"
+            onChange={(e) => setToDate(e.target.value)}
+            className="mb-6"
+            inputSize="sm"
+          />
+          <Button className="w-full" size="sm" onClick={handleApplyFilters}>
+            기사 검색하기
+          </Button>
+        </div>
+        <Button
+          className="w-full"
+          variant="secondary"
+          size="sm"
+          onClick={openModal}
+        >
+          기사 복구하기
+        </Button>
+        <ArticleModal
+          isOpen={isOpen}
+          onClose={onClose}
+          onSave={handleRestoreArticle}
+        />
+      </div>
+      <div className="min-w-48">
+        {keyword ? (
+          <div className="flex gap-4 items-center mb-8">
+            <div className="text-24-b text-cyan-600">{keyword}</div>
+            <div className="text-24-b text-slate-900">관련 기사 목록</div>
+          </div>
+        ) : interests.length > 0 ? (
+          <div className="flex gap-4 items-baseline mb-8">
+            <div className="min-w-[157px]">
+              <SelectBox
+                items={interestNames}
+                value={selectedInterest}
+                onChange={handleInterestChange}
+                placeholder="관심사 선택"
+                noBorder={true}
+                textClassName="text-24-b"
+                noBackground={true}
+              />
+            </div>
+            <div className="text-24-b text-slate-900">관련 기사 목록</div>
+          </div>
+        ) : (
+          <div className="text-24-b text-slate-900">관련 기사 목록</div>
+        )}
+        {articles.length === 0 ? (
+          <div className="min-w-[894px] w-full flex flex-col justify-center min-h-72 items-center gap-6 mt-30">
+            {interestId ? (
+              <EmptyState message="관련된 기사가 없습니다." />
+            ) : (
+              <div>
+                <EmptyState message="관심사를 등록하면 맞춤 기사를 확인하실 수 있어요." />
+                <Button
+                  onClick={() => navigate("/interests")}
+                  className="w-[160px]"
+                  size="sm"
+                >
+                  관심사 등록하기
+                </Button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div>
+            {articles.map((article, index) => (
+              <div
+                className="min-w-2xs"
+                key={article.id}
+                ref={index === articles.length - 1 ? lastElementRef : null}
+              >
+                <NewsCard article={article} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/InterestsPage.tsx
+++ b/src/pages/InterestsPage.tsx
@@ -326,16 +326,20 @@ function InterestsPage() {
         </div>
         <SearchBar width="w-[304px]" onSearch={handleSearch} />
       </div>
-      <div className="mt-4">
+      <div className="mt-4 min-w-2xs">
         {interests.length === 0 ? (
           <div className="flex justify-center items-center min-h-[200px] mt-30">
-            <EmptyState message="아직 등록한 관심사가 없습니다." />
+            {keyword ? (
+              <EmptyState message="검색 결과가 없습니다." />
+            ) : (
+              <EmptyState message="아직 등록한 관심사가 없습니다." />
+            )}
           </div>
         ) : (
           <div className="mt-4 flex flex-wrap gap-4">
             {interests.map((interest, index) => (
               <div
-                className="min-w-2xs"
+                className="w-[386px] h-[232px]"
                 key={interest.id}
                 ref={index === interests.length - 1 ? lastElementRef : null}
               >

--- a/src/shared/hooks/useArticleDetailModal.ts
+++ b/src/shared/hooks/useArticleDetailModal.ts
@@ -1,0 +1,19 @@
+import type { ArticleListItem } from "@/api/articles/types";
+import { useState } from "react";
+
+export default function useArticleDetailModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [modalData, setModalData] = useState<ArticleListItem | null>(null);
+
+  const openModal = (data: ArticleListItem) => {
+    setModalData(data);
+    setIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+    setModalData(null);
+  };
+
+  return { isOpen, openModal, onClose: closeModal, initialData: modalData };
+}

--- a/src/shared/hooks/useClosePopup.ts
+++ b/src/shared/hooks/useClosePopup.ts
@@ -4,10 +4,11 @@ import { useEffect } from "react";
 export const useClosePopup = (
   ref: React.RefObject<HTMLElement | null>,
   onClose: () => void,
-  isOpen: boolean = true
+  isOpen: boolean = true,
+  disableClose: boolean = false,
 ) => {
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || disableClose) return;
 
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as Node | null;
@@ -34,5 +35,5 @@ export const useClosePopup = (
       document.removeEventListener("mousedown", handleClickOutside, true);
       document.removeEventListener("keydown", handleKeyDown, true);
     };
-  }, [onClose, ref, isOpen]);
+  }, [onClose, ref, isOpen, disableClose]);
 };

--- a/src/shared/hooks/useConfirmModal.ts
+++ b/src/shared/hooks/useConfirmModal.ts
@@ -3,7 +3,7 @@ import { useState } from "react";
 interface ConfirmModalData {
   title: string;
   message: string;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
   confirmText?: string;
   cancelText?: string;
 }


### PR DESCRIPTION
## Description

- api/articles 에서 목록조회 할때 따로 `requestUserId: UserId`  이렇게 보내주니까, optional로 변경했습니다.
- 출처가 NAVER 밖에 없어서, Input 컴포넌트에 disabled가 필요해서 추가해줬습니다.
- 기사목록 부분에, "챔피언스리그" 부분과 같이 border, background, text 따로 스타일링 해줘야하는게 있어서 SelectBox 컴포넌트 수정했습니다.
-  태그에 onClick 필요없어서 지웠습니다.
- DropdownItem 중에 긴 글을 받는것도 있어서 `truncate`속성 추가해줬습니다.
- ArticleDetailModal은 기사를 누르면 나오는 기사 상세 모달입니다. 이에 따라, 훅도 추가해줬습니다.
- ConfirmModal 의 onConfirm Promise<void> 형식도 받을 수 있게 해줬습니다. (ArticleDetailModal에서 써야해서)
- ModalLayout에 padding이 필요없는게 있고 (기사 상세 모달에서, 댓글목록쪽 전체가 회색빛이여야하는데, padding 때문에 전체 회색빛 안됨.), width 가 필요한 모달이 있어서 추가해줬습니다. 
- 또한, 저는 기사 상세 모달, Confirm 모달 (정말 삭제하시겠습니까 모달) 을 2개 띄우다보니까, 각 모달 Layout이 useClosePopup으로 2개의 이벤트를 등록해버렸습니다. 그래서 두 모달의 배경이 화면 전체를 덮고 있다 보니 어디를 클릭하든 양쪽 리스너가 모두 "배경 클릭"으로 인식하고, 삭제버튼을 눌러도 모달이 닫히기만 하는 상황이라서, disableClose prop을 추가해주었습니다. 그래서 확인 모달이 열려있을 때는 기사 상세 모달의 이벤트 리스너를 비활성화하도록 해서 해결했습니다.
- NewsCard 에서 article 로 한번에 받았습니다.
- CommentCard 처음 구현할 때 수정만 만들었어서, 삭제 기능까지 구현해주었고, UI도 피그마에 맞춰서 변경했습니다.
- InterestCard 가로, 세로 높이 고정했습니다. 카드마다 width, height 다르다고 했던거요 !
- InterestPage 에서 검색결과 없는 EmptyState 없어서 추가해줬습니다.
- useClosePopup에서 disableClose 추가해줬습니다. (중복 모달 해결)

## 확인사항

- '기사 검색하기' 버튼을 추가해줬는데, 이유는, 원래는 정렬, 정렬 방향의 item을 바꾸면 그에 맞춰서 바로 검색되게 하려고 했으나, 밑에 날짜검색 구간이 있는데, 이부분은 검색 버튼이 있어야 구현이 가능해서, 그냥 "정렬" "정렬 방향" 도 `기사 검색하기`를 누르면 검색되게 했습니다.
- 그리고 NAVER 하나라서, 이 부분은 disabled 로 막아놨습니다.

## 스크린샷 (UI 변경 시)

<img width="1343" height="641" alt="스크린샷 2025-09-30 오후 11 29 50" src="https://github.com/user-attachments/assets/e2f336df-3f1d-4194-8974-4bae184aa415" />

<img width="1343" height="641" alt="스크린샷 2025-09-30 오후 11 30 02" src="https://github.com/user-attachments/assets/478255ae-888d-4c7a-bb5e-c426fb375585" />
<img width="1343" height="641" alt="스크린샷 2025-09-30 오후 11 30 16" src="https://github.com/user-attachments/assets/5af8a7f0-367e-436c-a381-4b1e0f90cdb9" />

<img width="1343" height="641" alt="스크린샷 2025-09-30 오후 11 30 19" src="https://github.com/user-attachments/assets/6142d58f-03f8-4861-8b5f-6799c88b5d03" />
<img width="340" height="656" alt="스크린샷 2025-09-30 오후 11 30 42" src="https://github.com/user-attachments/assets/bd4d92b4-ff5a-4df4-ae8b-b516ba62c0e1" />

https://github.com/user-attachments/assets/e30ed4e4-3417-40d7-8074-a7124697cb0b

<img width="972" height="767" alt="스크린샷 2025-09-30 오후 11 31 30" src="https://github.com/user-attachments/assets/e97e5bcd-146e-4f6d-b508-d39d89c6362d" />
<img width="972" height="767" alt="스크린샷 2025-09-30 오후 11 31 36" src="https://github.com/user-attachments/assets/8e98db25-9756-47f6-86ab-d40211f0c65b" />
<img width="972" height="767" alt="스크린샷 2025-09-30 오후 11 33 28" src="https://github.com/user-attachments/assets/cde9
<img width="972" height="767" alt="스크린샷 2025-09-30 오후 11 33 35" src="https://github.com/user-attachments/assets/2d69c210-6296-4dc0-9748-919c07832f28" />
8358-3932-4e15-b8a5-1b9414edb947" />
<img width="972" height="767" alt="스크린샷 2025-09-30 오후 11 33 39" src="https://github.com/user-attachments/assets/cb3067ee-17f1-4c9d-96f0-136e9fa9384e" />


## 체크리스트

- [x] 로컬에서 테스트 완료
- [x] 코드 스타일 확인
