### PR TITLE
:wrench: fix : 최근 본 기사 탭에서 기사 누르면 모달이 안 뜨는 오류 해결

### DIFF
--- a/src/components/modal/ArticleDetailModal.tsx
+++ b/src/components/modal/ArticleDetailModal.tsx
@@ -77,6 +77,7 @@ export default function ArticleDetailModal({
 
   const fetchInitialData = useCallback(async () => {
     setIsLoading(true);
+
     if (!data) return;
     try {
       const params = {

--- a/src/features/activities/components/ViewedArticleList.tsx
+++ b/src/features/activities/components/ViewedArticleList.tsx
@@ -37,7 +37,7 @@ export default function ViewedArticleList() {
     <ul className="flex flex-col gap-4 divide-y divide-gray-300">
       {items.map((a) => {
         const article: ArticleListItem = {
-          id: a.id,
+          id: a.articleId,
           title: a.articleTitle,
           summary: a.articleSummary,
           source: a.source,

--- a/src/pages/ArticlesPage.tsx
+++ b/src/pages/ArticlesPage.tsx
@@ -335,7 +335,7 @@ export default function ArticlesPage() {
   }, [fetchInitialData, orderBy, direction]);
 
   useEffect(() => {
-    if (articleId && !detailIsOpen) {
+    if (articleId) {
       if (stateArticle && stateArticle.id === articleId) {
         detailOpenModal(stateArticle);
       } else if (articles.length > 0) {
@@ -345,7 +345,7 @@ export default function ArticlesPage() {
         }
       }
     }
-  }, [articleId, articles, stateArticle, detailIsOpen]);
+  }, [articleId, articles, stateArticle]);
 
   const handleRestoreArticle = (data: RestoreArticlesParams) => {
     try {


### PR DESCRIPTION
## Description

- 모달이랑 페이지 이동 동시에 되서 안열리는 버그 해결했습니다.
- 이것도 개별 기사 검색 api 가 있었으면 편했을텐데, 그게 아니라서, `ViewedArticleList` 에서 state로 article 넘겨줘서 `ArticlePage` 에서 받아서 문제 해결했습니다.

그니까 상황이, 
1. 활동내역 -> 최근 본 기사 탭에서 특정 뉴스 클릭
2. /articles/{articleId} URL로 이동
3. ArticlesPage가 로드되면서 첫 5개 기사만 fetch됨
4. 첫 5개 기사에 해당 articleId가 없어서 모달 안 열림

## 스크린샷 (UI 변경 시)

<!-- 변경된 화면이 있다면 스크린샷 첨부 -->

## 체크리스트

- [x] 로컬에서 테스트 완료
- [x] 코드 스타일 확인
